### PR TITLE
Unselectable text and panel title fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,6 +7,17 @@
     list-style: none;
 }
 
+#tabs, #panels, #links, .row-end, h1 {
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select:none;
+	user-select:none;
+	-o-user-select:none; 
+	unselectable="on";
+	onselectstart="return false;" 
+	onmousedown="return false;"
+}
+
 :root {
     --accent: crimson;
     --bg: #0f0f12;

--- a/css/style.css
+++ b/css/style.css
@@ -464,7 +464,7 @@ body {
     padding: 1em;
     margin: auto;
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 1);
-    left: calc(50% - 40%);
+    left: calc(15% - 42.5px);
     bottom: 0;
     top: 0;
     background: rgba(0, 0, 0, .4);


### PR DESCRIPTION
I kept the text of the todos selectable because it might be useful but the rest of the page selects everything every time you click on the page.
Note that 42.5px is half the panel title box lenght